### PR TITLE
Add ability to toggle invitations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 TOMETO_FRONTEND_URL=http://localhost:1234
 TOMETO_BACKEND_URL=http://localhost:4001
 TOMETO_ENV=development
+
+T_INVITATIONS_REQUIRED=true

--- a/aph/config/config.example.exs
+++ b/aph/config/config.example.exs
@@ -6,7 +6,8 @@ config :aph,
   hostname: "http://localhost:4001",
   cookie_secret: "9RGqJxYrnc3eoQHrDBBdZsSCMytNFWqgsvD572DfPcm2uH+ycGFye8ulrwaFi+zp",
   # This is only useful if you are using the "google" TTS strategy.
-  google_key: "replaceme"
+  google_key: "replaceme",
+  require_invitations: true
 
 config :aph, Aph.Repo,
   username: "lu",

--- a/aph/lib/aph_web/auth.ex
+++ b/aph/lib/aph_web/auth.ex
@@ -12,6 +12,7 @@ defmodule AphWeb.Auth.Login do
   def authenticate(%{username: username, password: password}) do
     case Accounts.get_by_username(username) do
       nil -> {:error, "No user found!"}
+      {:error, reason} -> {:error, reason}
       {:ok, user} -> Argon2.check_pass(user, password, hash_key: :encrypted_password)
     end
   end

--- a/ui/src/components/TheHeader.vue
+++ b/ui/src/components/TheHeader.vue
@@ -49,7 +49,7 @@
           <span v-if="!hasInvitationsOn">
           <router-link
             class="nav__item"
-            to="/register"
+            to="/register/fakeinvitation"
           ><strong>Register</strong></router-link> |</span>
           <router-link
             class="nav__item"

--- a/ui/src/components/TheHeader.vue
+++ b/ui/src/components/TheHeader.vue
@@ -46,10 +46,11 @@
       </span>
       <span class="nav__subnav">
         <span v-if="!user">
+          <span v-if="!hasInvitationsOn">
           <router-link
             class="nav__item"
             to="/register"
-          ><strong>Register</strong></router-link> |
+          ><strong>Register</strong></router-link> |</span>
           <router-link
             class="nav__item"
             to="/login"
@@ -83,6 +84,9 @@ export default {
     },
     isStaging () {
       return process.env.TOMETO_ENV === 'staging'
+    },
+    hasInvitationsOn () {
+      return process.env.T_INVITATIONS_REQUIRED === 'true'
     }
   },
   beforeCreate () {


### PR DESCRIPTION
Closes #7 (finally). Adds a backend config setting and a frontend environment variable to toggle invitations. This doesn't disable them outright, it just means you can register without needing a valid invitation.